### PR TITLE
Create and use a unique cog module for each file processed.

### DIFF
--- a/cogapp/cogapp.py
+++ b/cogapp/cogapp.py
@@ -153,7 +153,7 @@ class CogGenerator(Redirectable):
         if not intext:
             return ''
 
-        prologue = "import cog\n"
+        prologue = "import " + cog.cogmodulename + " as cog\n"
         if self.options.sPrologue:
             prologue += self.options.sPrologue + '\n'
         code = compile(prologue + intext, str(fname), 'exec')
@@ -359,6 +359,7 @@ class Cog(Redirectable):
         Redirectable.__init__(self)
         self.options = CogOptions()
         self._fixEndOutputPatterns()
+        self.cogmodulename = "cog"
         self.installCogModule()
 
     def _fixEndOutputPatterns(self):
@@ -384,7 +385,6 @@ class Cog(Redirectable):
         """
         self.cogmodule = imp.new_module('cog')
         self.cogmodule.path = []
-        sys.modules['cog'] = self.cogmodule
 
     def openOutputFile(self, fname):
         """ Open an output file, taking all the details into account.
@@ -438,6 +438,10 @@ class Cog(Redirectable):
 
             self.cogmodule.inFile = sFileIn
             self.cogmodule.outFile = sFileOut
+            self.cogmodulename = 'cog_' + hashlib.md5(sFileOut).hexdigest()
+            sys.modules[self.cogmodulename] = self.cogmodule
+            # if "import cog" explicitly done in code by user, note threading will cause clashes. 
+            sys.modules['cog'] = self.cogmodule
 
             # The globals dict we'll use for this file.
             if globals is None:

--- a/cogapp/cogapp.py
+++ b/cogapp/cogapp.py
@@ -438,7 +438,7 @@ class Cog(Redirectable):
 
             self.cogmodule.inFile = sFileIn
             self.cogmodule.outFile = sFileOut
-            self.cogmodulename = 'cog_' + hashlib.md5(sFileOut).hexdigest()
+            self.cogmodulename = 'cog_' + hashlib.md5(sFileOut.encode()).hexdigest()
             sys.modules[self.cogmodulename] = self.cogmodule
             # if "import cog" explicitly done in code by user, note threading will cause clashes. 
             sys.modules['cog'] = self.cogmodule


### PR DESCRIPTION
Change-Id: Icd9f0aa7ff1f0714322ed90c9db16f0dffbc3a50

I use SCons for building, and as SCons is python I, just as Cog, have a "module" that can be imported into the Cog-files with various data. I then run Cog on the files by calling Cog.main() directly. However since Cog internally sets up a "cog" module that sets up output to correct files and this is imported by Cog-files, parallell building is not supported. I thus modified cogapp.py to create and use a unique "cog module" for each file that can be imported safely. This should have no effect on the nominal way with running cog.py from commandline, but enables parallell (threaded) building within one python interpreter instance.

cogapp automatically imports cog, so this does not need to be done by user. Documentation examples (and legacy code I assume), might explicitly "import cog", so I also added "cog" as a valid name for the "cog module", note this usage will then still cause clashes with threaded code (no worse than current master though).
