### PR TITLE
Optimize previous cog output handling

### DIFF
--- a/cogapp/cogapp.py
+++ b/cogapp/cogapp.py
@@ -501,7 +501,7 @@ class Cog(Redirectable):
 
                 # Eat all the lines in the output section.  While reading past
                 # them, compute the md5 hash of the old output.
-                previous = ""
+                previous = []
                 hasher = md5()
                 while l and not self.isEndOutputLine(l):
                     if self.isBeginSpecLine(l):
@@ -516,7 +516,7 @@ class Cog(Redirectable):
                             file=sFileIn,
                             line=fIn.linenumber(),
                         )
-                    previous += l
+                    previous.append(l)
                     hasher.update(l.encode("utf-8"))
                     l = fIn.readline()
                 curHash = hasher.hexdigest()
@@ -530,7 +530,7 @@ class Cog(Redirectable):
                     )
 
                 # Make the previous output available to the current code
-                self.cogmodule.previous = previous
+                self.cogmodule.previous = "".join(previous)
 
                 # Write the output of the spec to be the new output if we're
                 # supposed to generate code.


### PR DESCRIPTION
~Using StringIO for input and output files in all cases~

Storing the previous code present in the file as a list instead of a string

Fixes #29 