### PR TITLE
refactor: add ruff linting & fix initial violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           args: 'format --check'
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chartboost/ruff-action@v1
+
   tests:
     name: "Python ${{ matrix.python }} on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}-${{ matrix.os-version || 'latest' }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,4 @@ repos:
   rev: v0.4.1
   hooks:
   - id: ruff-format
+  - id: ruff

--- a/cogapp/__init__.py
+++ b/cogapp/__init__.py
@@ -4,4 +4,4 @@ http://nedbatchelder.com/code/cog
 Copyright 2004-2024, Ned Batchelder.
 """
 
-from .cogapp import Cog, CogUsageError, main
+from .cogapp import Cog as Cog, CogUsageError as CogUsageError, main as main

--- a/cogapp/test_cogapp.py
+++ b/cogapp/test_cogapp.py
@@ -709,7 +709,7 @@ class CogGeneratorGetCodeTests(TestCase):
         # the functions we're going to use.
         self.gen = CogGenerator()
         self.m = self.gen.parseMarker
-        self.l = self.gen.parseLine
+        self.parseLine = self.gen.parseLine
 
     def testEmpty(self):
         self.m("// [[[cog")
@@ -718,40 +718,40 @@ class CogGeneratorGetCodeTests(TestCase):
 
     def testSimple(self):
         self.m("// [[[cog")
-        self.l('  print "hello"')
-        self.l('  print "bye"')
+        self.parseLine('  print "hello"')
+        self.parseLine('  print "bye"')
         self.m("// ]]]")
         self.assertEqual(self.gen.getCode(), 'print "hello"\nprint "bye"')
 
     def testCompressed1(self):
         # For a while, I supported compressed code blocks, but no longer.
         self.m('// [[[cog: print """')
-        self.l("// hello")
-        self.l("// bye")
+        self.parseLine("// hello")
+        self.parseLine("// bye")
         self.m('// """)]]]')
         self.assertEqual(self.gen.getCode(), "hello\nbye")
 
     def testCompressed2(self):
         # For a while, I supported compressed code blocks, but no longer.
         self.m('// [[[cog: print """')
-        self.l("hello")
-        self.l("bye")
+        self.parseLine("hello")
+        self.parseLine("bye")
         self.m('// """)]]]')
         self.assertEqual(self.gen.getCode(), "hello\nbye")
 
     def testCompressed3(self):
         # For a while, I supported compressed code blocks, but no longer.
         self.m("// [[[cog")
-        self.l('print """hello')
-        self.l("bye")
+        self.parseLine('print """hello')
+        self.parseLine("bye")
         self.m('// """)]]]')
         self.assertEqual(self.gen.getCode(), 'print """hello\nbye')
 
     def testCompressed4(self):
         # For a while, I supported compressed code blocks, but no longer.
         self.m('// [[[cog: print """')
-        self.l("hello")
-        self.l('bye""")')
+        self.parseLine("hello")
+        self.parseLine('bye""")')
         self.m("// ]]]")
         self.assertEqual(self.gen.getCode(), 'hello\nbye""")')
 
@@ -759,9 +759,9 @@ class CogGeneratorGetCodeTests(TestCase):
         # It's important to be able to use #if 0 to hide lines from a
         # C++ compiler.
         self.m("#if 0 //[[[cog")
-        self.l("\timport cog, sys")
-        self.l("")
-        self.l("\tprint sys.argv")
+        self.parseLine("\timport cog, sys")
+        self.parseLine("")
+        self.parseLine("\tprint sys.argv")
         self.m("#endif //]]]")
         self.assertEqual(self.gen.getCode(), "import cog, sys\n\nprint sys.argv")
 

--- a/cogapp/test_makefiles.py
+++ b/cogapp/test_makefiles.py
@@ -26,7 +26,7 @@ class SimpleTests(TestCase):
     def checkFilesExist(self, d, dname):
         for fname in d.keys():
             assert self.exists(dname, fname)
-            if type(d[fname]) == type({}):
+            if isinstance(d[fname], dict):
                 self.checkFilesExist(d[fname], os.path.join(dname, fname))
 
     def checkFilesDontExist(self, d, dname):

--- a/cogapp/utils.py
+++ b/cogapp/utils.py
@@ -44,10 +44,10 @@ class NumberedFileReader:
         self.n = 0
 
     def readline(self):
-        l = self.f.readline()
-        if l:
+        line = self.f.readline()
+        if line:
             self.n += 1
-        return l
+        return line
 
     def linenumber(self):
         return self.n

--- a/cogapp/whiteutils.py
+++ b/cogapp/whiteutils.py
@@ -43,12 +43,12 @@ def reindentBlock(lines, newIndent=""):
         lines = lines.split(sep)
     oldIndent = whitePrefix(lines)
     outLines = []
-    for l in lines:
+    for line in lines:
         if oldIndent:
-            l = l.replace(oldIndent, nothing, 1)
-        if l and newIndent:
-            l = newIndent + l
-        outLines.append(l)
+            line = line.replace(oldIndent, nothing, 1)
+        if line and newIndent:
+            line = newIndent + line
+        outLines.append(line)
     return sep.join(outLines)
 
 


### PR DESCRIPTION
Re: #32 

Leaving out the `.git-blame-ignore-revs` update until we have the final commit hash rebased onto `main`.