### PR TITLE
Update setuptools requirement to version 80 or higher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,5 @@ packages = ["cogapp"]
 version.attr = "cogapp.cogapp.__version__"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=80"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Necessary to support `license` property changes