### PR TITLE
Stop raising exceptions on unexpected `]]]` characters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Unreleased
 
 - Dropped support for Python 3.9.
 
+- Stopped raising exceptions on unexpected ``]]]`` characters.
+
 
 3.6.0 – September 21 2025
 -------------------------

--- a/cogapp/cogapp.py
+++ b/cogapp/cogapp.py
@@ -233,12 +233,6 @@ class Cog(Redirectable):
             while line:
                 # Find the next spec begin
                 while line and not self.is_begin_spec_line(line):
-                    if self.is_end_spec_line(line):
-                        raise CogError(
-                            f"Unexpected {self.options.end_spec!r}",
-                            file=file_name_in,
-                            line=file_in.linenumber(),
-                        )
                     if self.is_end_output_line(line):
                         raise CogError(
                             f"Unexpected {self.options.end_output!r}",


### PR DESCRIPTION
This addresses errors that occur on valid files, like GitHub workflows that contain both cog usage and embedded Python with accurate type annotations. For example:

```yaml
on:
  push:
jobs:
  demo:
    runs-on: ubuntu-latest
    steps:
      - run: |
          # [[[cog cog.outl("echo 'hello'") ]]]
          echo 'hello'
          # [[[end]]]
      - shell: python
        run: |
          def demo() -> tuple[tuple[tuple[str]]]:
              #                              ^^^
              # This caused a failure        |||
              #
              return ((("hello world",),),)
          print(demo()[0][0][0])
```

Fixes #52